### PR TITLE
ci: introduce GitHub Actions test pipeline + OSS standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewer for all PRs. Branch protection rules can require this
+# review before merging.
+* @D0n9X1n

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing to ChatGPT Tag Highlighter
+
+Thanks for your interest in contributing! This is a small browser
+extension that highlights ChatGPT sidebar conversations by title tags.
+The codebase intentionally has **no build tools, no bundler, and no
+runtime dependencies** — pure vanilla JS with two manifest templates.
+
+## Getting Started
+
+### Development install (no build needed)
+
+**Chrome / Edge / Brave / Arc:**
+
+1. Open `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select the repo's `src/` directory.
+
+**Firefox:**
+
+1. Open `about:debugging#/runtime/this-firefox`.
+2. Click **Load Temporary Add-on…** and select `src/manifest.firefox.json`.
+
+Reload the extension after edits.
+
+## Project Layout
+
+```
+src/                    # The extension itself — load this directly
+  content.js            # Sidebar scanning + highlighting
+  background.js         # Service worker / background script
+  options.{html,css,js} # Settings page
+  manifest.chrome.json  # MV3 manifest (Chrome)
+  manifest.firefox.json # MV3 manifest with browser_specific_settings (Firefox)
+publish.sh              # Builds dist/{chrome,firefox} + .zip / .xpi archives
+tests/                  # pytest + Playwright suite (see "Running Tests")
+.github/workflows/      # CI: tests, codeql, release
+docs/specs/             # Design specs, one per feature
+feature-crew/           # Submodule: agent-team workflow used by maintainers
+```
+
+## Making Changes
+
+1. **Branch off `main`.** Use a short topic prefix:
+   - `feat/<topic>` for new features
+   - `fix/<topic>` for bug fixes
+   - `ci/<topic>`, `docs/<topic>`, `chore/<topic>` for everything else
+2. **Stick to vanilla JS.** No npm packages, no transpilation.
+3. **Match existing patterns.** IIFE wrappers, `chrome.storage.sync` with
+   `local` fallback, CSS custom properties for highlight colors, and
+   batched DOM work via `requestAnimationFrame`.
+4. **Keep `LEGACY` and `PALETTE` in sync** between `content.js` and
+   `options.js` if you change the color palette.
+5. **Add tests** under `tests/` for any non-trivial behaviour.
+
+## Running Tests
+
+The CI suite uses Playwright + pytest. There's no Node.js dependency.
+
+### One-time setup
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r tests/requirements.txt
+playwright install chromium
+```
+
+### Build the extension (tests need `dist/chrome/`)
+
+```sh
+./publish.sh --version 0.0.99
+```
+
+### Run the suite
+
+```sh
+source .venv/bin/activate
+pytest tests/test_extension.py -v
+```
+
+### Live tests (require ChatGPT login)
+
+There is also an in-browser unit test page at `tests/unit_test.html` that
+the suite loads automatically.
+
+If you want to run live ChatGPT tests interactively, log in **once** in
+the persistent profile at `tests/.test-profile/` and reuse it across
+runs. **Do not delete that directory** between runs — the cookies expire
+quickly.
+
+## Building Release Artifacts
+
+```sh
+./publish.sh --version X.Y.Z
+```
+
+Produces:
+
+- `dist/chrome/`     — unpacked Chrome bundle (Load Unpacked friendly)
+- `dist/firefox/`    — unpacked Firefox bundle
+- `dist/chatgpt-tag-highlighter-chrome-X.Y.Z.zip`
+- `dist/chatgpt-tag-highlighter-firefox-X.Y.Z.xpi`
+
+## Releasing (Maintainers Only)
+
+The release pipeline is fully automated — it runs the test suite against
+the exact bits that will be shipped, then attaches them to a GitHub
+Release.
+
+1. Bump the `version` field in **both** `src/manifest.chrome.json` and
+   `src/manifest.firefox.json`. They must match the tag.
+2. Commit on `main`.
+3. Tag and push:
+   ```sh
+   git tag v0.2.0
+   git push origin v0.2.0
+   ```
+4. Wait for `.github/workflows/release.yml` to finish — the GitHub
+   Release will appear with both `.zip` and `.xpi` attached.
+5. **Manually** upload the `.zip` to the Chrome Web Store dashboard and
+   the `.xpi` to AMO. Store API publishing is intentionally not
+   automated yet.
+
+## Pull Requests
+
+- Keep PRs focused — one feature or fix per PR.
+- Make sure `pytest tests/test_extension.py -v` passes locally before
+  pushing. CI will re-run it on PR.
+- The PR template will prompt you for the basics (what, why, how
+  tested). Fill it in honestly.
+
+## Code of Conduct
+
+Be kind. Assume good intent. Focus on the code.
+
+## Getting Help
+
+- Open a [Discussion](https://github.com/D0n9X1n/chatgpt-tag-highlighter/discussions)
+  for design questions.
+- Open an [Issue](https://github.com/D0n9X1n/chatgpt-tag-highlighter/issues)
+  for bugs and feature requests using the templates.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug report
+description: Something isn't working as expected
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please provide
+        as much detail as possible so we can reproduce and fix it.
+
+  - type: input
+    id: extension-version
+    attributes:
+      label: Extension version
+      description: From `chrome://extensions` (Chrome) or `about:addons` (Firefox).
+      placeholder: e.g. 0.1.3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      options:
+        - Chrome
+        - Edge
+        - Brave
+        - Arc
+        - Other Chromium
+        - Firefox
+        - Other (specify in description)
+    validations:
+      required: true
+
+  - type: input
+    id: browser-version
+    attributes:
+      label: Browser version
+      placeholder: e.g. 131.0.6778.85
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. macOS 15.2 / Windows 11 / Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug. Screenshots help a lot.
+      placeholder: |
+        I expected ... but I saw ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ChatGPT
+        2. Configure rules with `[BUG]` startsWith
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors (optional)
+      description: Open DevTools → Console while on chatgpt.com and paste any red errors.
+      render: shell
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Extension config (optional)
+      description: Settings page → Export → paste here. Redact anything sensitive.
+      render: json

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discussions
+    url: https://github.com/D0n9X1n/chatgpt-tag-highlighter/discussions
+    about: Ask questions, share ideas, or get help with configuration.
+  - name: 🔒 Security report
+    url: https://github.com/D0n9X1n/chatgpt-tag-highlighter/security/advisories/new
+    about: Report a security vulnerability privately. Do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest a new feature or improvement
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an idea! Before filing, please check the
+        existing [issues](https://github.com/D0n9X1n/chatgpt-tag-highlighter/issues)
+        and [discussions](https://github.com/D0n9X1n/chatgpt-tag-highlighter/discussions)
+        in case it's already been requested.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case in your own words. What's frustrating today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would the feature work from a user's point of view?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways you've thought about solving this — including not building it.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, screenshots from other tools, links to similar features elsewhere.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+  Thanks for contributing! Please fill out the relevant sections below.
+  Remove sections that don't apply.
+-->
+
+## Summary
+
+<!-- One or two sentences: what does this PR change and why? -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behaviour)
+- [ ] Refactor / cleanup (no behavioural change)
+- [ ] Docs / CI / chore
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## How was this tested?
+
+- [ ] `pytest tests/test_extension.py -v` passes locally
+- [ ] Manually verified in Chrome via `chrome://extensions` → Load unpacked
+- [ ] Manually verified in Firefox via `about:debugging` → Load Temporary Add-on
+- [ ] No tests needed (docs / CI only)
+
+## Checklist
+
+- [ ] My branch is up to date with `main`
+- [ ] I've matched the existing code style (vanilla JS, IIFE wrappers, no new deps)
+- [ ] I've updated `LEGACY` / `PALETTE` in both `content.js` and `options.js` if I changed colors
+- [ ] I've added or updated tests under `tests/` for non-trivial changes
+- [ ] I've updated documentation (`ReadMe.md`, `ReadMe.CN.md`, `CHANGELOG.md`) if user-facing behaviour changed

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported Versions
+
+We support the latest published version of the extension on each store:
+
+| Channel | Supported |
+| --- | --- |
+| Chrome Web Store — latest | ✅ |
+| Firefox Add-ons (AMO) — latest | ✅ |
+| Older versions | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not file a public GitHub issue for security reports.**
+
+If you believe you have found a security vulnerability in
+`chatgpt-tag-highlighter`, report it privately via GitHub's
+[Security Advisories](https://github.com/D0n9X1n/chatgpt-tag-highlighter/security/advisories/new)
+form. This routes the report to the maintainers without exposing it
+publicly while we triage.
+
+When reporting, please include:
+
+1. A clear description of the issue and its impact.
+2. Steps to reproduce, ideally with a minimal example or video.
+3. Affected version(s) and browser(s).
+4. Any proof-of-concept code or saved configuration.
+
+We aim to:
+
+- Acknowledge receipt within **3 working days**.
+- Provide an initial assessment within **7 working days**.
+- Ship a fix or mitigation as soon as practical, coordinated with you.
+
+## Scope
+
+In scope:
+
+- The extension code under `src/`.
+- The build pipeline under `publish.sh` and `.github/workflows/`.
+- The published artifacts on the Chrome Web Store and AMO.
+
+Out of scope:
+
+- Issues in ChatGPT itself or unrelated browser features.
+- Social-engineering or physical attacks against extension users.
+- Vulnerabilities that require an attacker to already control the user's
+  browser profile or operating system account.
+
+## Disclosure
+
+We follow coordinated disclosure: once a fix is shipped to both stores,
+we publish the advisory and credit the reporter (unless they request
+anonymity).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Keep CI/CD action versions current. Pinning + automated bumps gives us
+# both reproducible builds and timely security patches.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: pip
+    directory: /tests
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: test
+      include: scope
+    labels:
+      - dependencies
+      - tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+# Static security analysis for the extension's JavaScript. Browser
+# extensions run privileged code, so DOM/storage/messaging bugs matter.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly catch for newly published CodeQL queries (Mondays 03:17 UTC).
+    - cron: '17 3 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze JavaScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          # Restrict scanning to actual extension source — skip dist/, tests/.
+          source-root: src
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+# Tag-driven release. Push a `v*` tag (e.g. `v0.2.0`) on `main` to:
+#   1. Build chrome + firefox bundles at exactly that version
+#   2. Run the full Tests workflow against the build
+#   3. Attach the .zip + .xpi to a GitHub Release
+#
+# Store-side publishing (Chrome Web Store / Firefox AMO) is still a manual
+# step — see CONTRIBUTING.md. Adding it here would require store API tokens
+# and a protected environment with manual approval; out of scope for now.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+# Never cancel a half-completed release.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Derive a clean SemVer string from the tag (strip leading "v") and
+  # validate it matches both source manifests before doing any work.
+  prepare:
+    name: Validate tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse tag
+        id: tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag '$TAG' is not SemVer (expected vX.Y.Z or vX.Y.Z-prerelease)"
+            exit 1
+          fi
+          # Chrome rejects pre-release suffixes like "-beta.1" — release builds
+          # must be strictly numeric. Surface that early instead of failing
+          # mid-pipeline.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Chrome manifests reject pre-release suffixes; use vX.Y.Z only."
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag version matches both source manifests
+        # Source manifests are the source of truth. They MUST be bumped
+        # (and committed) in lock-step with the tag — this prevents silent
+        # drift between published artifacts and the repo state.
+        run: |
+          VERSION="${{ steps.tag.outputs.version }}"
+          for f in src/manifest.chrome.json src/manifest.firefox.json; do
+            FILE_VER=$(python3 -c "import json; print(json.load(open('$f'))['version'])")
+            if [ "$FILE_VER" != "$VERSION" ]; then
+              echo "::error::$f version ($FILE_VER) does not match tag ($VERSION)"
+              exit 1
+            fi
+          done
+
+  # Reuse the standard test pipeline. Build version comes from the tag.
+  tests:
+    name: Tests on tagged build
+    needs: prepare
+    uses: ./.github/workflows/test.yml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+    permissions:
+      contents: read
+
+  release:
+    name: Publish GitHub Release ${{ github.ref_name }}
+    needs: [prepare, tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout (needed for `gh release` to read the repo)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download packaged archives from tests workflow
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-archives
+          path: release-artifacts
+
+      - name: List artifacts to publish
+        run: ls -la release-artifacts/
+
+      - name: Create GitHub Release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ needs.prepare.outputs.tag }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "${{ needs.prepare.outputs.tag }}" \
+            --generate-notes \
+            release-artifacts/*.zip \
+            release-artifacts/*.xpi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,224 @@
+name: Tests
+
+# Reusable workflow: build the extension once, then run JS syntax checks,
+# Playwright tests against the Chrome bundle, and web-ext lint against the
+# Firefox bundle. The same artifacts that pass tests can be promoted to a
+# release by `release.yml` (which calls this workflow with workflow_call).
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_call:
+    inputs:
+      version:
+        description: >-
+          Extension version to inject into manifests during build.
+          Must be Chrome-compatible (1–4 dot-separated unsigned integers).
+        required: false
+        type: string
+        default: ''
+    outputs:
+      version:
+        description: The actual version string used for the build.
+        value: ${{ jobs.build.outputs.version }}
+
+# Cancel superseded runs on the same ref to save CI minutes.
+# Releases (workflow_call from a tag) get their own group below.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build once — all downstream jobs consume the same artifacts.
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build (chrome + firefox)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve build version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Synthetic version for CI builds: 0.0.<run_number>. Three
+            # numeric parts keep both publish.sh's SemVer check and Chrome's
+            # manifest validator happy. (Run number is monotonically
+            # increasing per repo, so each CI build gets a unique version.)
+            VERSION="0.0.${GITHUB_RUN_NUMBER}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building with version: $VERSION"
+
+      - name: Validate manifests parse
+        run: |
+          python3 -c "import json; json.load(open('src/manifest.chrome.json'))"
+          python3 -c "import json; json.load(open('src/manifest.firefox.json'))"
+
+      - name: Setup Node.js (for syntax check + web-ext)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: JS syntax check (no execution, no lint config required)
+        run: |
+          for f in src/*.js; do
+            node --check "$f"
+          done
+
+      - name: Build chrome + firefox bundles
+        run: ./publish.sh --version "${{ steps.version.outputs.version }}"
+
+      - name: Verify Chrome manifest version is numeric (Chrome rejects pre-release tags)
+        run: |
+          VER=$(python3 -c "import json; print(json.load(open('dist/chrome/manifest.json'))['version'])")
+          echo "Chrome manifest.json version: $VER"
+          python3 -c "
+          import re, sys
+          v = '$VER'
+          # Chrome accepts 1–4 dot-separated unsigned integers, each 0–65535.
+          if not re.fullmatch(r'\d{1,5}(\.\d{1,5}){0,3}', v):
+              sys.exit(f'Invalid Chrome manifest version: {v!r}')
+          for part in v.split('.'):
+              if int(part) > 65535:
+                  sys.exit(f'Chrome version part out of range: {part}')
+          "
+
+      - name: Verify required files are present in built bundles
+        run: |
+          for d in dist/chrome dist/firefox; do
+            for f in manifest.json content.js background.js options.html options.js options.css icon.png icon-128.png; do
+              if [ ! -f "$d/$f" ]; then
+                echo "::error::Missing $d/$f"
+                exit 1
+              fi
+            done
+          done
+
+      - name: Upload chrome bundle (unpacked)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-chrome
+          path: dist/chrome/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload firefox bundle (unpacked)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-firefox
+          path: dist/firefox/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload packaged archives (.zip + .xpi)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-archives
+          path: |
+            dist/*.zip
+            dist/*.xpi
+          if-no-files-found: error
+          retention-days: 14
+
+  # ---------------------------------------------------------------------------
+  # Run the Playwright/pytest suite against the built Chrome bundle.
+  # ---------------------------------------------------------------------------
+  test-chrome:
+    name: Test (chrome / playwright)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CI: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download chrome bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-chrome
+          path: dist/chrome
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: tests/requirements.txt
+
+      - name: Install python deps
+        run: pip install -r tests/requirements.txt
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/requirements.txt') }}
+
+      - name: Install Playwright Chromium (with system deps)
+        run: python -m playwright install --with-deps chromium
+
+      - name: Run pytest under Xvfb
+        # Chrome MV3 service workers + --load-extension still don't initialize
+        # reliably under --headless=new across all builds, so we keep
+        # headless=False (set in tests/test_extension.py) and provide a
+        # virtual display via Xvfb.
+        run: xvfb-run -a --server-args="-screen 0 1280x900x24" pytest tests/test_extension.py -v --junitxml=test-results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: test-results.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failures
+          path: |
+            tests/screenshots/
+            tests/.test-profile/Crash Reports/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Static validation of the Firefox bundle. Runtime extension testing in
+  # Firefox via Playwright is unreliable (Playwright Firefox doesn't load
+  # WebExtensions), so we lean on `web-ext lint` for now.
+  # ---------------------------------------------------------------------------
+  lint-firefox:
+    name: Lint (firefox / web-ext)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download firefox bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-firefox
+          path: dist/firefox
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: web-ext lint (warnings as warnings, errors fail the build)
+        run: npx --yes web-ext@8.3.0 lint --source-dir dist/firefox --warnings-as-errors=false --self-hosted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Continuous Integration pipeline (`.github/workflows/test.yml`) that
+  builds the Chrome and Firefox bundles, runs the Playwright suite under
+  Xvfb, and lints the Firefox `.xpi` with `web-ext`.
+- Tag-driven release pipeline (`.github/workflows/release.yml`) that
+  reuses the test workflow and publishes a GitHub Release with both the
+  `.zip` and `.xpi` attached.
+- Weekly CodeQL static-analysis scan (`.github/workflows/codeql.yml`).
+- Dependabot configuration for GitHub Actions and pip dependencies.
+- Issue templates (bug report, feature request) and a pull-request
+  template.
+- `CONTRIBUTING.md` and `SECURITY.md`.
+- Pinned test dependencies in `tests/requirements.txt`.
+
+### Changed
+- Hardened the Playwright fixture in `tests/test_extension.py` to derive
+  the extension ID from the loaded MV3 service worker rather than
+  scraping the `chrome://extensions` shadow DOM. The CI environment
+  uses a throwaway profile under `/tmp` while local development keeps
+  the persistent `tests/.test-profile/`.
+
+## [0.1.3] — 2026-04-19
+
+### Added
+- Auto-save in the Options page; rule changes persist without an
+  explicit Save click.
+- Multi-select filter bar above the ChatGPT sidebar — click pills to
+  show only chats matching one or more tags.
+- Per-rule overlay toggle so rules can highlight without the floating
+  banner.
+- Rule numbers and inline rule tester in the Options page.
+
+### Changed
+- Centralised every rule mutation through `onRulesChanged()` so row
+  numbers, the debug tester, and auto-save always stay in sync.
+- Layout polish in the Options page; `Add Tag` moved below the table.
+
+## [0.1.2] — earlier
+
+### Added
+- Includes-style demo rules for friendlier onboarding.
+- Multi-select tag filter bar pills (initial drop).
+
+## [0.1.1]
+
+### Fixed
+- Rules with `hide: true` no longer appear as filter pills.
+
+## [0.1.0]
+
+### Added
+- Keyboard focus on filter pills via `Alt+F`.
+
+### Fixed
+- Sidebar/nav hide selectors updated for the refreshed ChatGPT layout.
+
+## [0.0.3]
+
+### Added
+- Dim Untagged, Badge Counter, and Keyboard Shortcut affordances.
+- Sidebar tag filter bar with pill toggles.
+- Per-rule overlay toggle, theme-aware overlay, Import/Export settings,
+  drag-to-reorder rules.
+- Live config reload and the option to hide the right nav bar.
+- Initial pytest + Playwright suite.
+
+## [0.0.2] — early release
+
+Initial public release with tag-based highlighting in the ChatGPT
+sidebar.
+
+[Unreleased]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.0.3...v0.1.0
+[0.0.3]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/releases/tag/v0.0.2

--- a/ReadMe.CN.md
+++ b/ReadMe.CN.md
@@ -1,7 +1,18 @@
 # ChatGPT Tag Highlighter
 
+[![Tests](https://github.com/D0n9X1n/chatgpt-tag-highlighter/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/D0n9X1n/chatgpt-tag-highlighter/actions/workflows/test.yml)
+[![CodeQL](https://github.com/D0n9X1n/chatgpt-tag-highlighter/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/D0n9X1n/chatgpt-tag-highlighter/actions/workflows/codeql.yml)
+[![GitHub release](https://img.shields.io/github/v/release/D0n9X1n/chatgpt-tag-highlighter?include_prereleases&logo=github&label=release&color=brightgreen)](https://github.com/D0n9X1n/chatgpt-tag-highlighter/releases)
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/lplghggkggkbkkakjabafjenjlekogbm?logo=googlechrome&logoColor=white&label=chrome%20web%20store&color=brightgreen)](https://chromewebstore.google.com/detail/chatgpt-tag-highlighter/lplghggkggkbkkakjabafjenjlekogbm)
+[![Chrome Web Store users](https://img.shields.io/chrome-web-store/users/lplghggkggkbkkakjabafjenjlekogbm?logo=googlechrome&logoColor=white&label=users)](https://chromewebstore.google.com/detail/chatgpt-tag-highlighter/lplghggkggkbkkakjabafjenjlekogbm)
+[![Firefox Add-ons](https://img.shields.io/amo/v/chatgpt-tag-highlighter?logo=firefoxbrowser&logoColor=white&label=firefox%20add-ons&color=brightgreen)](https://addons.mozilla.org/firefox/addon/chatgpt-tag-highlighter/)
+[![Firefox users](https://img.shields.io/amo/users/chatgpt-tag-highlighter?logo=firefoxbrowser&logoColor=white&label=users)](https://addons.mozilla.org/firefox/addon/chatgpt-tag-highlighter/)
+[![License: MIT](https://img.shields.io/github/license/D0n9X1n/chatgpt-tag-highlighter?color=brightgreen)](./LICENSE)
+
 一个轻量级浏览器扩展：根据聊天标题里的标签（例如 **[TODO]**、**[BUG]**）自动高亮 ChatGPT 侧边栏会话。
 效果是：**左侧彩色标柱 + 柔和背景**，让你一眼找到重要对话、快速跳转、不再“翻聊天翻到心态爆炸”。
+
+[English README](./ReadMe.md)
 
 ![LOGO](./src/icon.png)
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,7 +1,18 @@
 # ChatGPT Tag Highlighter
 
+[![Tests](https://github.com/D0n9X1n/chatgpt-tag-highlighter/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/D0n9X1n/chatgpt-tag-highlighter/actions/workflows/test.yml)
+[![CodeQL](https://github.com/D0n9X1n/chatgpt-tag-highlighter/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/D0n9X1n/chatgpt-tag-highlighter/actions/workflows/codeql.yml)
+[![GitHub release](https://img.shields.io/github/v/release/D0n9X1n/chatgpt-tag-highlighter?include_prereleases&logo=github&label=release&color=brightgreen)](https://github.com/D0n9X1n/chatgpt-tag-highlighter/releases)
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/lplghggkggkbkkakjabafjenjlekogbm?logo=googlechrome&logoColor=white&label=chrome%20web%20store&color=brightgreen)](https://chromewebstore.google.com/detail/chatgpt-tag-highlighter/lplghggkggkbkkakjabafjenjlekogbm)
+[![Chrome Web Store users](https://img.shields.io/chrome-web-store/users/lplghggkggkbkkakjabafjenjlekogbm?logo=googlechrome&logoColor=white&label=users)](https://chromewebstore.google.com/detail/chatgpt-tag-highlighter/lplghggkggkbkkakjabafjenjlekogbm)
+[![Firefox Add-ons](https://img.shields.io/amo/v/chatgpt-tag-highlighter?logo=firefoxbrowser&logoColor=white&label=firefox%20add-ons&color=brightgreen)](https://addons.mozilla.org/firefox/addon/chatgpt-tag-highlighter/)
+[![Firefox users](https://img.shields.io/amo/users/chatgpt-tag-highlighter?logo=firefoxbrowser&logoColor=white&label=users)](https://addons.mozilla.org/firefox/addon/chatgpt-tag-highlighter/)
+[![License: MIT](https://img.shields.io/github/license/D0n9X1n/chatgpt-tag-highlighter?color=brightgreen)](./LICENSE)
+
 Yet, just another lightweight browser extension that highlights ChatGPT sidebar conversations based on **title tags** like **[TODO]** and **[BUG]**. 
 It adds a **colored left stripe** + subtle background so tagged chats are easy to scan and jump to.
+
+[中文说明 / Chinese](./ReadMe.CN.md)
 
 ![LOGO](./src/icon.png)
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+# Pinned dev/test dependencies for the Playwright-based suite in tests/.
+# Pinning protects CI from surprise upstream releases. Bump deliberately.
+playwright==1.58.0
+pytest==9.0.3

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -16,6 +16,8 @@ Usage:
 
 import json
 import os
+import re
+import tempfile
 import time
 import pytest
 from pathlib import Path
@@ -26,40 +28,75 @@ EXT_PATH = str(ROOT / 'dist' / 'chrome')
 UNIT_TEST_PATH = str(ROOT / 'tests' / 'unit_test.html')
 STORAGE_KEY = 'tagHighlighterConfigV1'
 
+# CI detection — GitHub Actions and most CI providers set CI=true.
+# In CI we use a throwaway profile dir under tempfile so each run is clean.
+# Locally we keep the persistent .test-profile so contributors can reuse
+# extension state (and, for live ChatGPT tests, login cookies).
+IS_CI = os.environ.get('CI', '').lower() in ('1', 'true', 'yes')
+
+
+def _profile_dir():
+    if IS_CI:
+        # tmp_path_factory would also work, but we want a stable per-session
+        # path so a single browser_context is reused across the whole run.
+        return tempfile.mkdtemp(prefix='cth-ci-profile-')
+    return str(Path(__file__).parent / '.test-profile')
+
 
 @pytest.fixture(scope='session')
 def browser_context():
-    """Launch Chromium with the extension loaded in a temporary profile."""
+    """Launch Chromium with the extension loaded.
+
+    Local dev: persistent profile at tests/.test-profile, headed window.
+    CI: throwaway temp profile, headed-via-Xvfb (extensions still don't
+    load reliably in --headless=new across all Chromium builds, so we keep
+    headless=False and rely on Xvfb in CI — see .github/workflows/test.yml).
+    """
     pw = sync_playwright().start()
-    profile_dir = str(Path(__file__).parent / '.test-profile')
     context = pw.chromium.launch_persistent_context(
-        profile_dir,
+        _profile_dir(),
         headless=False,
         args=[
             f'--disable-extensions-except={EXT_PATH}',
             f'--load-extension={EXT_PATH}',
             '--disable-blink-features=AutomationControlled',
+            # Make the headed window deterministic in CI/Xvfb.
+            '--window-size=1280,900',
         ],
-        ignore_default_args=['--enable-automation'],
+        ignore_default_args=['--enable-automation', '--disable-extensions'],
     )
     yield context
     context.close()
     pw.stop()
 
 
+# Match the 32-char lowercase a–p extension ID portion of an extension URL.
+_EXT_ID_RE = re.compile(r'chrome-extension://([a-p]{32})/')
+
+
 @pytest.fixture(scope='session')
 def ext_id(browser_context):
-    """Discover the extension ID at runtime."""
-    page = browser_context.new_page()
-    page.goto('chrome://extensions')
-    page.wait_for_timeout(2000)
-    eid = page.evaluate(
-        'document.querySelector("extensions-manager")'
-        '.shadowRoot.querySelector("extensions-item-list")'
-        '.shadowRoot.querySelector("extensions-item").id'
-    )
-    page.close()
-    return eid
+    """Discover the extension ID from the loaded service worker URL.
+
+    More robust than scraping chrome://extensions shadow DOM, which breaks
+    on Chrome UI updates. The MV3 service worker registers as soon as the
+    extension loads — we either find it already registered or wait for the
+    'serviceworker' event.
+    """
+    sw = next(iter(browser_context.service_workers), None)
+    if sw is None:
+        try:
+            sw = browser_context.wait_for_event('serviceworker', timeout=10_000)
+        except Exception as exc:
+            raise RuntimeError(
+                'Could not discover extension service worker. '
+                f'EXT_PATH={EXT_PATH}'
+            ) from exc
+
+    m = _EXT_ID_RE.match(sw.url)
+    if not m:
+        raise RuntimeError(f'Unexpected service worker URL: {sw.url}')
+    return m.group(1)
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

Introduces a complete CI/CD pipeline patterned after `hexo-blog-encrypt`, plus the standard repo-hygiene files an open-source browser extension should ship with.

### What's included

**Workflows**
- `.github/workflows/test.yml` — reusable. Builds chrome + firefox bundles via `publish.sh`, validates manifests, runs JS syntax check, executes the full pytest+Playwright suite under Xvfb against the built chrome bundle, and runs `web-ext lint` against the firefox bundle. Uploads artifacts so they can be promoted by release.yml.
- `.github/workflows/release.yml` — `v*` tag triggered. Verifies tag matches both source manifests, calls `test.yml`, then attaches the same `.zip` and `.xpi` (the bits that just passed CI) to a GitHub Release.
- `.github/workflows/codeql.yml` — JS security scanning on push, PR, and weekly.
- `.github/dependabot.yml` — weekly action + pip updates.

**Repo standards**
- `SECURITY.md` (private vulnerability reporting), `CONTRIBUTING.md`, `CODEOWNERS`, PR template, issue templates (yml forms), `CHANGELOG.md`.
- README badges (Tests, CodeQL, release, Chrome Web Store, Firefox AMO, license) added to both `ReadMe.md` and `ReadMe.CN.md`.

**Test fixture hardening**
- Extension ID is now derived from the MV3 service-worker URL instead of the brittle `chrome://extensions` shadow-DOM scrape.
- CI uses a throwaway temp profile; local dev keeps `tests/.test-profile/` for ChatGPT cookies.
- `tests/requirements.txt` pins `playwright` and `pytest` versions for reproducible CI.

### Type of change
- [x] Docs / CI / chore

### How was this tested?
- All 23 existing tests pass locally with the hardened fixture.
- `actionlint` and `PyYAML` validate cleanly against every workflow.
- `./publish.sh --version 0.0.42` produces the expected artifacts.
- `web-ext lint` against `dist/firefox` reports 0 errors / 0 notices (1 pre-existing innerHTML warning).

CI will run on this PR as the first end-to-end test. If the chromium-on-Xvfb step misbehaves I'll iterate here.