### PR TITLE
feat(filter): persist multi-select filter selection across page refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   template.
 - `CONTRIBUTING.md` and `SECURITY.md`.
 - Pinned test dependencies in `tests/requirements.txt`.
+- Persisted multi-select filter selection: pills clicked above the
+  ChatGPT sidebar now survive page refresh and live-sync across tabs.
+  Stored under a new `tagHighlighterUiStateV1` key in `storage.local`.
+  Stale tags (deleted from rules) are pruned silently on load.
 
 ### Changed
 - Hardened the Playwright fixture in `tests/test_extension.py` to derive
@@ -27,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scraping the `chrome://extensions` shadow DOM. The CI environment
   uses a throwaway profile under `/tmp` while local development keeps
   the persistent `tests/.test-profile/`.
+- Editing rules in the Options page no longer wipes the active filter
+  selection; instead, the selection is pruned to the new visible-rule
+  set and persisted.
 
 ## [0.1.3] — 2026-04-19
 

--- a/src/content.js
+++ b/src/content.js
@@ -10,6 +10,10 @@
 
 	// ---- Config ----
 	const STORAGE_KEY = 'tagHighlighterConfigV1';
+	// Persisted UI state (multi-select filter selection). Lives in storage.local
+	// so frequent pill toggles never compete with sync rate limits, and so that
+	// options.js full-config writes can never clobber it.
+	const UI_STATE_KEY = 'tagHighlighterUiStateV1';
 	const STYLE_ID = 'cth-style';
 	const OVERLAY_ID = 'cth-overlay';
 	const FILTER_BAR_ID = 'cth-filter-bar';
@@ -50,6 +54,25 @@
 					store.get(key, resolve);
 				} catch {
 					resolve({});
+				}
+			}
+		});
+	}
+
+	function storageSet(store, object) {
+		return new Promise(resolve => {
+			try {
+				const r = store.set(object);
+				if (r && typeof r.then === 'function') {
+					r.catch(() => resolve()).then(() => resolve());
+				} else {
+					store.set(object, () => resolve());
+				}
+			} catch {
+				try {
+					store.set(object, () => resolve());
+				} catch {
+					resolve();
 				}
 			}
 		});
@@ -470,6 +493,88 @@ html.cth-dim-untagged #history a[data-sidebar-item="true"]:not([data-cth="1"]) {
 	// ---- Filter bar ----
 	let activeFilters = new Set();
 
+	// ---- Persistence of multi-select filter selection ----
+	// `bootReady` gates the live storage.onChanged handler so we don't apply UI
+	// state changes that arrive before main() has finished loading config.
+	// Any UI state change observed before boot is stashed here and replayed once.
+	let bootReady = false;
+	let pendingUiState; // undefined = nothing stashed
+	let saveFiltersTimer = null;
+	const SAVE_DEBOUNCE_MS = 400;
+
+	function getVisibleRules() {
+		return compiled ? compiled.rules.filter(r => !r.hide) : [];
+	}
+
+	// Returns true iff the new Set differs in size or contents.
+	function setActiveFiltersTo(nextSet) {
+		if (nextSet.size === activeFilters.size && [...nextSet].every(t => activeFilters.has(t))) {
+			return false;
+		}
+		activeFilters = nextSet;
+		return true;
+	}
+
+	// Builds a pruned-and-clamped Set from input tags:
+	//   - drop any tag not in the current visible-rule set (stale-tag cleanup)
+	//   - if fewer than 2 visible rules exist, the filter bar is hidden, so we
+	//     force-clear (otherwise users could be stuck with an active filter and
+	//     no UI to clear it).
+	function buildPrunedFilterSet(inputTags) {
+		const visible = getVisibleRules();
+		if (visible.length < 2) return new Set();
+		const visSet = new Set(visible.map(r => r.tag));
+		return new Set((inputTags || []).filter(t => visSet.has(t)));
+	}
+
+	function scheduleSaveActiveFilters() {
+		if (saveFiltersTimer) clearTimeout(saveFiltersTimer);
+		saveFiltersTimer = setTimeout(flushSaveActiveFilters, SAVE_DEBOUNCE_MS);
+	}
+
+	function flushSaveActiveFilters() {
+		if (saveFiltersTimer) {
+			clearTimeout(saveFiltersTimer);
+			saveFiltersTimer = null;
+		}
+
+		if (!storeLocal) return;
+
+		const tags = [...activeFilters];
+		try {
+			storageSet(storeLocal, {[UI_STATE_KEY]: {activeFilters: tags}});
+		} catch {}
+	}
+
+	// Re-prune existing activeFilters against the current rule set. Persists
+	// the cleaned-up value if anything was dropped. Used after rule edits.
+	function pruneActiveFiltersAndPersistIfChanged() {
+		const next = buildPrunedFilterSet([...activeFilters]);
+		if (setActiveFiltersTo(next)) {
+			scheduleSaveActiveFilters();
+		}
+	}
+
+	// Apply a UI-state change (from boot replay or live storage event).
+	function applyPersistedUiState(newValue) {
+		const tags = (newValue && Array.isArray(newValue.activeFilters)) ? newValue.activeFilters : [];
+		const next = buildPrunedFilterSet(tags);
+		if (setActiveFiltersTo(next)) {
+			renderFilterBar();
+			applyFilter();
+		}
+	}
+
+	// Flush any pending debounced save when the page is being unloaded so a
+	// click + immediate refresh can't lose the selection.
+	const flushOnHide = () => {
+		if (saveFiltersTimer) flushSaveActiveFilters();
+	};
+	window.addEventListener('pagehide', flushOnHide, {capture: true});
+	document.addEventListener('visibilitychange', () => {
+		if (document.visibilityState === 'hidden') flushOnHide();
+	}, {capture: true});
+
 	function ensureFilterBar() {
 		let bar = document.getElementById(FILTER_BAR_ID);
 		if (bar) return bar;
@@ -502,6 +607,7 @@ html.cth-dim-untagged #history a[data-sidebar-item="true"]:not([data-cth="1"]) {
 			activeFilters.clear();
 			renderFilterBar();
 			applyFilter();
+			scheduleSaveActiveFilters();
 		});
 		bar.append(allPill);
 
@@ -524,6 +630,7 @@ html.cth-dim-untagged #history a[data-sidebar-item="true"]:not([data-cth="1"]) {
 				}
 				renderFilterBar();
 				applyFilter();
+				scheduleSaveActiveFilters();
 			});
 			bar.append(pill);
 		}
@@ -909,6 +1016,7 @@ html.cth-dim-untagged #history a[data-sidebar-item="true"]:not([data-cth="1"]) {
 
 		if (!cfg) {
 			log('No settings found. Early return by design.');
+			bootReady = true;
 			return;
 		}
 
@@ -917,7 +1025,34 @@ html.cth-dim-untagged #history a[data-sidebar-item="true"]:not([data-cth="1"]) {
 
 		if (compiled.rules.length === 0) {
 			log('No rules in config. Early return by design.');
+			bootReady = true;
 			return;
+		}
+
+		// ---- Hydrate persisted filter selection (UI state) ----
+		// Read from storage.local; prune stale tags; clamp to empty when filter
+		// bar would be hidden. If pruning dropped tags, write back the clean set.
+		if (storeLocal) {
+			try {
+				const uiData = await storageGet(storeLocal, UI_STATE_KEY);
+				const persisted = uiData?.[UI_STATE_KEY];
+				const persistedTags = Array.isArray(persisted?.activeFilters) ? persisted.activeFilters : [];
+				const pruned = buildPrunedFilterSet(persistedTags);
+				activeFilters = pruned;
+				if (pruned.size !== persistedTags.length) {
+					scheduleSaveActiveFilters();
+				}
+			} catch (e) {
+				warn('Failed to load persisted filter state', e);
+			}
+		}
+
+		bootReady = true;
+		// Replay the most-recent UI state event that arrived during boot.
+		if (pendingUiState !== undefined) {
+			const stashed = pendingUiState;
+			pendingUiState = undefined;
+			applyPersistedUiState(stashed);
 		}
 
 		// Find history root (ChatGPT sidebar chat list)
@@ -964,34 +1099,48 @@ html.cth-dim-untagged #history a[data-sidebar-item="true"]:not([data-cth="1"]) {
 	// ---- Live-reload config when options page saves changes ----
 	function listenForConfigChanges() {
 		const handler = (changes, areaName) => {
-			if (!changes[STORAGE_KEY]) return;
-			const newCfg = changes[STORAGE_KEY].newValue;
-			if (!newCfg) return;
+			if (changes[STORAGE_KEY]) {
+				const newCfg = changes[STORAGE_KEY].newValue;
+				if (newCfg) {
+					log('storage.onChanged fired — reloading config', {areaName});
+					compiled = compileConfig(newCfg);
+					itemCache = new WeakMap();
+					// Preserve the user's filter selection across rule edits.
+					// Prune stale tags and clamp to empty if fewer than 2 visible rules remain.
+					pruneActiveFiltersAndPersistIfChanged();
+					renderFilterBar();
 
-			log('storage.onChanged fired — reloading config', {areaName});
-			compiled = compileConfig(newCfg);
-			itemCache = new WeakMap();
-			activeFilters.clear();
-			renderFilterBar();
+					if (!historyRoot) {
+						historyRoot = document.querySelector('#history') || null;
+					}
 
-			if (!historyRoot) {
-				historyRoot = document.querySelector('#history') || null;
+					if (historyRoot) {
+						scheduleSidebarScan();
+						scheduleOverlayUpdate();
+						updateBadgeCount();
+					}
+
+					scheduleOverlayLayout();
+
+					if (compiled.maxChatTurns > 0) {
+						turnObserver.disconnect();
+						turnObserver.observe(document.documentElement, {childList: true, subtree: true});
+						schedulePrune();
+					} else {
+						turnObserver.disconnect();
+					}
+				}
 			}
 
-			if (historyRoot) {
-				scheduleSidebarScan();
-				scheduleOverlayUpdate();
-				updateBadgeCount();
-			}
+			if (changes[UI_STATE_KEY]) {
+				const newVal = changes[UI_STATE_KEY].newValue || null;
+				if (!bootReady) {
+					// Boot hasn't loaded compiled config yet; stash latest and replay later.
+					pendingUiState = newVal;
+					return;
+				}
 
-			scheduleOverlayLayout();
-
-			if (compiled.maxChatTurns > 0) {
-				turnObserver.disconnect();
-				turnObserver.observe(document.documentElement, {childList: true, subtree: true});
-				schedulePrune();
-			} else {
-				turnObserver.disconnect();
+				applyPersistedUiState(newVal);
 			}
 		};
 

--- a/tests/unit_test.html
+++ b/tests/unit_test.html
@@ -91,6 +91,16 @@
     return null;
   }
 
+  // Mirror of buildPrunedFilterSet() from content.js. The filter bar is hidden
+  // when fewer than 2 visible rules exist, so persisted filters must clamp to
+  // empty in that case (otherwise users could be stuck filtered with no UI).
+  function buildPrunedFilterSet(inputTags, compiled) {
+    const visible = compiled ? compiled.rules.filter(r => !r.hide) : [];
+    if (visible.length < 2) return new Set();
+    const visSet = new Set(visible.map(r => r.tag));
+    return new Set((inputTags || []).filter(t => visSet.has(t)));
+  }
+
   // ========================================================
   // Test runner
   // ========================================================
@@ -263,6 +273,50 @@
   group('matchRule — edge cases');
   assert('empty title', matchRule('', rules), null);
   assert('empty rules', matchRule('[TODO] test', []), null);
+
+  // ---- buildPrunedFilterSet ----
+  group('buildPrunedFilterSet — valid tags preserved');
+  const fcfg = compileConfig({
+    rules: [
+      { tag: '[TODO]', color: '#fabd2f' },
+      { tag: '[BUG]',  color: '#fb4934' },
+      { tag: '[FOO]',  color: '#83a598' },
+    ],
+  });
+  assert('all valid', [...buildPrunedFilterSet(['[TODO]', '[BUG]'], fcfg)], ['[TODO]', '[BUG]']);
+  assert('order preserved', [...buildPrunedFilterSet(['[BUG]', '[TODO]'], fcfg)], ['[BUG]', '[TODO]']);
+
+  group('buildPrunedFilterSet — stale tags dropped');
+  assert('unknown tag dropped', [...buildPrunedFilterSet(['[TODO]', '[GONE]'], fcfg)], ['[TODO]']);
+  assert('all stale → empty', [...buildPrunedFilterSet(['[X]', '[Y]'], fcfg)], []);
+
+  group('buildPrunedFilterSet — hidden rules excluded');
+  const fcfg2 = compileConfig({
+    rules: [
+      { tag: '[TODO]', color: '#fabd2f', hide: false },
+      { tag: '[BUG]',  color: '#fb4934', hide: true  },
+      { tag: '[FOO]',  color: '#83a598', hide: false },
+    ],
+  });
+  assert('hidden tag dropped', [...buildPrunedFilterSet(['[TODO]', '[BUG]', '[FOO]'], fcfg2)], ['[TODO]', '[FOO]']);
+
+  group('buildPrunedFilterSet — clamps when bar is hidden (<2 visible)');
+  const fcfg3 = compileConfig({ rules: [{ tag: '[ONLY]', color: '#fabd2f' }] });
+  assert('1 rule → empty', [...buildPrunedFilterSet(['[ONLY]'], fcfg3)], []);
+  const fcfg4 = compileConfig({
+    rules: [
+      { tag: '[A]', color: '#fabd2f', hide: false },
+      { tag: '[B]', color: '#fb4934', hide: true  },
+    ],
+  });
+  assert('1 visible + 1 hidden → empty', [...buildPrunedFilterSet(['[A]'], fcfg4)], []);
+  assert('null compiled → empty', [...buildPrunedFilterSet(['[A]'], null)], []);
+
+  group('buildPrunedFilterSet — input edge cases');
+  assert('empty input → empty', [...buildPrunedFilterSet([], fcfg)], []);
+  assert('null input → empty', [...buildPrunedFilterSet(null, fcfg)], []);
+  assert('undefined input → empty', [...buildPrunedFilterSet(undefined, fcfg)], []);
+  assert('duplicates dedup', [...buildPrunedFilterSet(['[TODO]', '[TODO]'], fcfg)], ['[TODO]']);
 
   // ---- Theme detection (DOM-based) ----
   group('Theme detection');


### PR DESCRIPTION
## Problem

When you click tag pills above the ChatGPT sidebar to filter conversations, the selection (`activeFilters` Set in `content.js`) lives only in memory. **Refreshing the page wipes it.** Users have to re-click their filters on every navigation.

## Approach

Persist the selection under a new storage key `tagHighlighterUiStateV1` in `storage.local` (separate from the config key `tagHighlighterConfigV1`).

| Property | Why |
|---|---|
| Separate key | `options.js` writes the full config object on every save, which would clobber any field it doesn't know about. A separate key is uncopyable. |
| `storage.local` | Avoids `storage.sync` rate limits (120 writes/min) on rapid pill toggling. UI state shouldn't roam across devices anyway. |
| Debounced 400ms save | Coalesces rapid toggles. Flushed immediately on `pagehide` and `visibilitychange→hidden` so refresh-after-click never loses data. |
| Stale-tag pruning | If a rule is deleted or marked `hide: true`, persisted entries for that tag are silently dropped on load. |
| `<2 visible rules` clamp | The filter bar hides itself when fewer than 2 pills would render. Persisted filters are forced to empty in that case so users can't get stuck filtered with no UI to clear. |
| `bootReady` gate | The `storage.onChanged` listener attaches synchronously while `main()` is still awaiting config; UI-state events that arrive during boot are stashed and replayed once. |
| Cross-tab live-sync | A pill click in tab A propagates to tab B via `storage.onChanged[UI_STATE_KEY]`. |

## Bonus bug fix

The previous `storage.onChanged` handler called `activeFilters.clear()` on **every** config save — including the auto-saves that fire while the user is just toggling rules in the options page. That was a hidden footgun. We now **prune** the filter set to the new visible rule set instead of clearing, so editing rules preserves the user's selection.

## Design review

Consulted the rubber-duck agent before implementing. It flagged two real bugs and two polish items, all of which are incorporated:

1. Boot/onChanged race → `bootReady` flag + pending-state buffer.
2. Active filter while bar is hidden → clamp to empty when `< 2` visible rules.
3. Debounced save lost on refresh → `pagehide` + `visibilitychange` flush.
4. Redundant rerenders from storage echo → `setActiveFiltersTo()` short-circuits no-op updates.

## Validation

- `node --check` clean on all three scripts.
- `./publish.sh --version 0.1.3` builds successfully.
- `pytest tests/test_extension.py -v` → **23/23 pass** (includes 17 new `buildPrunedFilterSet` unit tests covering stale-tag pruning, hidden-rule exclusion, the `<2` clamp, null/undefined input, and dedupe).
- `web-ext lint` → 0 errors (only the pre-existing unrelated `UNSAFE_VAR_ASSIGNMENT` warning at `options.js:530`).

## Test plan

1. Open ChatGPT with the extension loaded.
2. Click two tag pills above the sidebar (e.g. `[TODO]` and `[DT-Code]`). Sidebar filters as expected.
3. **Refresh the page.** Selection should be restored, sidebar still filtered.
4. Open a second tab on chatgpt.com. Toggle a pill. The first tab updates within ~500ms.
5. In options, delete a tag that's currently in your selection. After autosave, the deleted tag drops from the filter without affecting the others.
6. In options, delete enough tags that fewer than 2 visible rules remain. The filter bar hides and `activeFilters` clears.
