### PR TITLE
chore(release): bump to v1.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Extension version
       description: From `chrome://extensions` (Chrome) or `about:addons` (Firefox).
-      placeholder: e.g. 0.1.3
+      placeholder: e.g. 1.0.0
     validations:
       required: true
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,10 +48,10 @@ All three scripts detect the extension API at runtime (`browser` vs `chrome`) an
 ## Build & publish
 
 ```sh
-./publish.sh --version 0.1.3
+./publish.sh --version 1.0.0
 ```
 
-This produces `dist/chatgpt-tag-highlighter-chrome-0.1.3.zip` and `dist/chatgpt-tag-highlighter-firefox-0.1.3.xpi`. Requires `python3` and `zip`.
+This produces `dist/chatgpt-tag-highlighter-chrome-1.0.0.zip` and `dist/chatgpt-tag-highlighter-firefox-1.0.0.xpi`. Requires `python3` and `zip`.
 
 There is no build step for development — load `src/` directly as an unpacked extension in Chrome, or as a temporary add-on in Firefox.
 
@@ -73,7 +73,7 @@ Open `tests/unit_test.html` in a browser. Tests pure functions (`toHex`, `hexToR
 ### E2E tests (automated, options page)
 
 ```sh
-./publish.sh --version 0.1.3          # build dist/chrome/ first
+./publish.sh --version 1.0.0          # build dist/chrome/ first
 source .venv/bin/activate
 pytest tests/test_extension.py -v
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-05-04
+
+First stable release. The extension is now considered feature-complete
+for v1: tag-based highlighting, sidebar filter, hide / dim / overlay
+controls, multi-select filter persistence, and a hardened CI/release
+pipeline.
+
 ### Added
 - Continuous Integration pipeline (`.github/workflows/test.yml`) that
   builds the Chrome and Firefox bundles, runs the Playwright suite under
@@ -34,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editing rules in the Options page no longer wipes the active filter
   selection; instead, the selection is pruned to the new visible-rule
   set and persisted.
+- `LICENSE` replaced with the canonical SPDX `MIT License` header so
+  GitHub now reports the repository as MIT.
 
 ## [0.1.3] — 2026-04-19
 
@@ -85,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Initial public release with tag-based highlighting in the ChatGPT
 sidebar.
 
-[Unreleased]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.3...v1.0.0
 [0.1.3]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/D0n9X1n/chatgpt-tag-highlighter/compare/v0.1.0...v0.1.1

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ChatGPT Tag Highlighter",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "Highlight ChatGPT sidebar chats by tags like [TODO] with custom colors.",
   "icons": {
     "128": "icon-128.png"

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ChatGPT Tag Highlighter",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "Highlight ChatGPT sidebar chats by tags like [TODO] with custom colors.",
   "icons": {
     "128": "icon-128.png"


### PR DESCRIPTION
First stable release. After the CI/release pipeline, MIT relicense, dependabot wave, and persisted-filter feature, the extension is feature-complete enough to graduate from the `0.0.x` series.

## Bumps

| File | From | To |
|---|---|---|
| `src/manifest.chrome.json` | `0.0.3` | `1.0.0` |
| `src/manifest.firefox.json` | `0.0.3` | `1.0.0` |

## CHANGELOG

The accumulated `Unreleased` section is finalized as `## [1.0.0] — 2026-05-04`, covering: CI pipeline, release workflow, CodeQL, dependabot, issue/PR templates, `CONTRIBUTING.md` + `SECURITY.md`, hardened Playwright fixture, persisted filter selection, prune-not-clear on rule edits, and canonical MIT `LICENSE`.

## Other docs

- `.github/ISSUE_TEMPLATE/bug_report.yml` — version placeholder bumped to `1.0.0`.
- `.github/copilot-instructions.md` — `publish.sh` examples bumped.

## Release flow

After this PR merges I'll tag `v1.0.0` on `main`, which triggers `.github/workflows/release.yml`:

1. Validates the tag is plain SemVer (`X.Y.Z`, no pre-release).
2. Verifies both source manifests match the tag version.
3. Builds + tests at the tagged version (full Playwright + web-ext lint).
4. Creates a GitHub Release with the `.zip` and `.xpi` attached.

Store-side publishing (Chrome Web Store / Firefox AMO) remains a manual step per `CONTRIBUTING.md`.
