### PR TITLE
fix(options): use DOM nodes in rule tester to close CodeQL #1

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -248,6 +248,17 @@ th{
   padding: 2px 0;
 }
 
+/* Smaller inline swatch used inside the rule tester results. Overrides the
+   global .swatch sizing so the marker fits on a single line of text. */
+.debugResult .swatch{
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: none;
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
 .debugResult code{
   background: rgba(255,255,255,.08);
   padding: 1px 5px;

--- a/src/options.js
+++ b/src/options.js
@@ -493,27 +493,24 @@
 		onRulesChanged();
 	});
 
-	// ---- HTML escape (kept for any future template literal use; runDebugTest
-	// uses DOM nodes + textContent so CodeQL recognizes the sanitization.) ----
-	const ESC_MAP = {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'};
-	const escapeHtml = s => String(s ?? '').replaceAll(/[&<>"']/g, c => ESC_MAP[c]);
-
 	// Build the small swatch span used by the rule tester. `hex` is already
 	// normalized to /^#[0-9a-f]{6}$/ by toHex(), so .style.background is safe.
+	// Sizing/alignment live in options.css under .debugResult .swatch.
 	function buildSwatch(hex) {
 		const sw = document.createElement('span');
 		sw.className = 'swatch';
-		sw.style.cssText = 'width:12px;height:12px;display:inline-block;border-radius:3px;vertical-align:middle;margin:0 4px';
 		sw.style.background = hex;
 		return sw;
 	}
 
 	// Build one result row. `tag` is user-controlled — only ever assigned via
 	// textContent (never innerHTML), so XSS payloads render as literal text.
-	function buildResultRow(className, idx, hex, tag, matchKind, suffix) {
+	// `marker` is the leading glyph (✓ or ✗) — passed in rather than mutated
+	// after the fact, so the caller never has to reach into .firstChild.
+	function buildResultRow(className, marker, idx, hex, tag, matchKind, suffix) {
 		const div = document.createElement('div');
 		div.className = className;
-		div.append(document.createTextNode(`✓ #${idx + 1} `));
+		div.append(document.createTextNode(`${marker} #${idx + 1} `));
 		div.append(buildSwatch(hex));
 		div.append(document.createTextNode(' '));
 		const code = document.createElement('code');
@@ -552,16 +549,12 @@
 				const b = document.createElement('b');
 				b.textContent = 'WINNER';
 				winner.append(b);
-				nodes.push(buildResultRow('matchHit', i, hex, tag, match, winner));
+				nodes.push(buildResultRow('matchHit', '✓', i, hex, tag, match, winner));
 			} else if (hit) {
 				const suffix = document.createTextNode(` — matches but skipped (rule #${winnerIdx + 1} won)`);
-				nodes.push(buildResultRow('matchSkipped', i, hex, tag, match, suffix));
+				nodes.push(buildResultRow('matchSkipped', '✓', i, hex, tag, match, suffix));
 			} else {
-				// Miss rows render the same shape but with a leading ✗ marker.
-				const div = buildResultRow('matchMiss', i, hex, tag, match, null);
-				// Replace the leading "✓ #N " text node with "✗ #N ".
-				div.firstChild.textContent = `✗ #${i + 1} `;
-				nodes.push(div);
+				nodes.push(buildResultRow('matchMiss', '✗', i, hex, tag, match, null));
 			}
 		}
 

--- a/src/options.js
+++ b/src/options.js
@@ -493,21 +493,50 @@
 		onRulesChanged();
 	});
 
-	// ---- HTML escape (prevents XSS via user-controlled tag/title) ----
+	// ---- HTML escape (kept for any future template literal use; runDebugTest
+	// uses DOM nodes + textContent so CodeQL recognizes the sanitization.) ----
 	const ESC_MAP = {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'};
 	const escapeHtml = s => String(s ?? '').replaceAll(/[&<>"']/g, c => ESC_MAP[c]);
+
+	// Build the small swatch span used by the rule tester. `hex` is already
+	// normalized to /^#[0-9a-f]{6}$/ by toHex(), so .style.background is safe.
+	function buildSwatch(hex) {
+		const sw = document.createElement('span');
+		sw.className = 'swatch';
+		sw.style.cssText = 'width:12px;height:12px;display:inline-block;border-radius:3px;vertical-align:middle;margin:0 4px';
+		sw.style.background = hex;
+		return sw;
+	}
+
+	// Build one result row. `tag` is user-controlled — only ever assigned via
+	// textContent (never innerHTML), so XSS payloads render as literal text.
+	function buildResultRow(className, idx, hex, tag, matchKind, suffix) {
+		const div = document.createElement('div');
+		div.className = className;
+		div.append(document.createTextNode(`✓ #${idx + 1} `));
+		div.append(buildSwatch(hex));
+		div.append(document.createTextNode(' '));
+		const code = document.createElement('code');
+		code.textContent = tag;
+		div.append(code);
+		div.append(document.createTextNode(` (${matchKind})`));
+		if (suffix) {
+			div.append(suffix);
+		}
+		return div;
+	}
 
 	// ---- Rule tester ----
 	function runDebugTest() {
 		const title = els.debugTitle.value.trim();
 		if (!title) {
-			els.debugResult.innerHTML = 'Type a title above to see which rule matches.';
+			els.debugResult.textContent = 'Type a title above to see which rule matches.';
 			return;
 		}
 
 		const trs = els.rows.querySelectorAll('tr');
 		let winnerIdx = -1;
-		const lines = [];
+		const nodes = [];
 
 		for (let i = 0; i < trs.length; i++) {
 			const tag = String(trs[i].querySelector('.tag').value || '').trim();
@@ -515,25 +544,36 @@
 			const match = safeMatch(trs[i].querySelector('.match').value);
 			const hit = match === 'startsWith' ? title.startsWith(tag) : title.includes(tag);
 			const hex = toHex(trs[i].querySelector('.hex').value);
-			const safeTag = escapeHtml(tag);
-			// hex is normalized to /^#[0-9a-f]{6}$/ by toHex() and match is whitelisted by safeMatch() — both safe to interpolate.
-			const swatch = `<span class="swatch" style="background:${hex};width:12px;height:12px;display:inline-block;border-radius:3px;vertical-align:middle;margin:0 4px"></span>`;
 
 			if (hit && winnerIdx === -1) {
 				winnerIdx = i;
-				lines.push(`<div class="matchHit">✓ #${i + 1} ${swatch} <code>${safeTag}</code> (${match}) — <b>WINNER</b></div>`);
+				const winner = document.createElement('span');
+				winner.append(document.createTextNode(' — '));
+				const b = document.createElement('b');
+				b.textContent = 'WINNER';
+				winner.append(b);
+				nodes.push(buildResultRow('matchHit', i, hex, tag, match, winner));
 			} else if (hit) {
-				lines.push(`<div class="matchSkipped">✓ #${i + 1} ${swatch} <code>${safeTag}</code> (${match}) — matches but skipped (rule #${winnerIdx + 1} won)</div>`);
+				const suffix = document.createTextNode(` — matches but skipped (rule #${winnerIdx + 1} won)`);
+				nodes.push(buildResultRow('matchSkipped', i, hex, tag, match, suffix));
 			} else {
-				lines.push(`<div class="matchMiss">✗ #${i + 1} ${swatch} <code>${safeTag}</code> (${match})</div>`);
+				// Miss rows render the same shape but with a leading ✗ marker.
+				const div = buildResultRow('matchMiss', i, hex, tag, match, null);
+				// Replace the leading "✓ #N " text node with "✗ #N ".
+				div.firstChild.textContent = `✗ #${i + 1} `;
+				nodes.push(div);
 			}
 		}
 
 		if (winnerIdx === -1) {
-			lines.push(`<div class="matchNone">✗ No rule matches "${escapeHtml(title)}"</div>`);
+			const noneDiv = document.createElement('div');
+			noneDiv.className = 'matchNone';
+			// textContent guarantees `title` is rendered as literal text.
+			noneDiv.textContent = `✗ No rule matches "${title}"`;
+			nodes.push(noneDiv);
 		}
 
-		els.debugResult.innerHTML = lines.join('');
+		els.debugResult.replaceChildren(...nodes);
 	}
 
 	els.debugTitle.addEventListener('input', runDebugTest);

--- a/tests/unit_test.html
+++ b/tests/unit_test.html
@@ -91,11 +91,6 @@
     return null;
   }
 
-  // Mirror of escapeHtml() from options.js — used by the rule tester to prevent
-  // XSS via user-controlled tag/title text (CodeQL js/xss-through-dom).
-  const ESC_MAP = {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'};
-  const escapeHtml = s => String(s ?? '').replaceAll(/[&<>"']/g, c => ESC_MAP[c]);
-
   // Mirror of buildPrunedFilterSet() from content.js. The filter bar is hidden
   // when fewer than 2 visible rules exist, so persisted filters must clamp to
   // empty in that case (otherwise users could be stuck filtered with no UI).
@@ -322,57 +317,6 @@
   assert('null input → empty', [...buildPrunedFilterSet(null, fcfg)], []);
   assert('undefined input → empty', [...buildPrunedFilterSet(undefined, fcfg)], []);
   assert('duplicates dedup', [...buildPrunedFilterSet(['[TODO]', '[TODO]'], fcfg)], ['[TODO]']);
-
-  // ---- escapeHtml (XSS prevention in rule tester) ----
-  group('escapeHtml — basic chars');
-  assert('& escaped', escapeHtml('a&b'), 'a&amp;b');
-  assert('< escaped', escapeHtml('a<b'), 'a&lt;b');
-  assert('> escaped', escapeHtml('a>b'), 'a&gt;b');
-  assert('" escaped', escapeHtml('a"b'), 'a&quot;b');
-  assert("' escaped", escapeHtml("a'b"), 'a&#39;b');
-  assert('all chars together', escapeHtml(`<&>"'`), '&lt;&amp;&gt;&quot;&#39;');
-
-  group('escapeHtml — XSS payloads');
-  assert('script tag neutralized',
-    escapeHtml('<script>alert(1)</' + 'script>'),
-    '&lt;script&gt;alert(1)&lt;/script&gt;');
-  assert('img onerror neutralized',
-    escapeHtml('<img src=x onerror=alert(1)>'),
-    '&lt;img src=x onerror=alert(1)&gt;');
-  assert('svg onload neutralized',
-    escapeHtml(`<svg onload="alert('xss')">`),
-    '&lt;svg onload=&quot;alert(&#39;xss&#39;)&quot;&gt;');
-  assert('attribute-break neutralized',
-    escapeHtml('" onmouseover="alert(1)'),
-    '&quot; onmouseover=&quot;alert(1)');
-
-  group('escapeHtml — edge cases');
-  assert('empty string', escapeHtml(''), '');
-  assert('null → empty', escapeHtml(null), '');
-  assert('undefined → empty', escapeHtml(undefined), '');
-  assert('plain text unchanged', escapeHtml('[TODO] hello'), '[TODO] hello');
-  assert('number coerced', escapeHtml(42), '42');
-  assert('no double-escape on re-entry',
-    escapeHtml(escapeHtml('<a>')),
-    '&amp;lt;a&amp;gt;');
-
-  // Functional: simulate what runDebugTest produces and verify the
-  // resulting innerHTML does NOT materialize attacker-controlled elements.
-  group('escapeHtml — runDebugTest sink behavior');
-  const _sink = document.createElement('div');
-  const _tag = '<img src=x onerror=alert(1)>';
-  _sink.innerHTML = `<div class="matchHit"><code>${escapeHtml(_tag)}</code></div>`;
-  assert('no <img> materialized from escaped tag',
-    _sink.querySelector('img'), null);
-  assert('literal text preserved in textContent',
-    _sink.querySelector('code').textContent, _tag);
-
-  const _sink2 = document.createElement('div');
-  const _title = '<script>window.__pwned=true</' + 'script>';
-  _sink2.innerHTML = `<div>No rule matches "${escapeHtml(_title)}"</div>`;
-  assert('no <script> materialized from escaped title',
-    _sink2.querySelector('script'), null);
-  assert('window.__pwned never set', window.__pwned, undefined);
 
   // ---- Theme detection (DOM-based) ----
   group('Theme detection');


### PR DESCRIPTION
## Summary
Follow-up to #18. That PR fixed the actual XSS (browser test proves payloads don't execute), but CodeQL alert #1 stayed **open** because its taint analysis doesn't recognize regex-based sanitizers like `escapeHtml`. The `innerHTML` sink kept being flagged at `options.js:536`.

This PR rewrites `runDebugTest` to build the result tree with `createElement` + `textContent` + `replaceChildren`. User-controlled `tag` and `title` only ever flow into `.textContent`, which CodeQL recognizes as a true sanitizer.

## What changed
- `runDebugTest` no longer constructs HTML strings; uses DOM API throughout.
- Two small helpers: `buildSwatch(hex)` and `buildResultRow(className, marker, idx, hex, tag, matchKind, suffix)`.
- Static empty-state string switched from `innerHTML` to `textContent` (was already safe, but consistent).
- `.debugResult .swatch` CSS rule added in `options.css` so the smaller inline swatch sizing lives in one place; `buildSwatch()` only sets `background`.
- `escapeHtml`/`ESC_MAP` helper removed (dead after the rewrite); 22 corresponding unit assertions removed.

## Verification
- ✅ **24/24 pytest pass**, including `test_rule_tester_does_not_execute_injected_html` from #18 (still valid — checks both DOM materialization and `window.__pwned`).
- ✅ **82/82 unit assertions pass** (back to pre-#18 baseline since the `escapeHtml`-specific assertions are gone with the helper).
- ✅ `node --check src/options.js` clean.

Expected: post-merge CodeQL run on `main` will mark alert #1 as `fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)